### PR TITLE
Add example of deserializing with type-hinting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,11 @@ root.field = new Derived();
 JsonWriter writer = new JsonWriter();
 writer.TypeHinting = true;
 string json = JsonMapper.ToJson(root, writer);
+
+// To deserialize the resulting JSON, use a JsonReader with TypeHinting set to true.
+JsonReader reader = new JsonReader(json);
+reader.TypeHinting = true
+Root deserializedRoot = JsonMapper.ToObject<Root>(reader);
 ```
 
 The resultant JSON will be as follows:


### PR DESCRIPTION
Had to dive in to the source to figure out why my type-hinted JSON wasn't deserializing properly. In retrospective it makes sense that you'd need to tell LitJson to deserialize with type-hinting, but it would have been easier if the example had spelled it out.
